### PR TITLE
Review of only-authentication

### DIFF
--- a/only-authentication/README.md
+++ b/only-authentication/README.md
@@ -154,20 +154,21 @@ Edit the `/etc/rabbitmq/rabbitmq.config` file, add the following configuration a
 ```
 [
     {rabbit, [
-        {auth_backends, [rabbit_auth_backend_LDAP]}
+        {auth_backends, [rabbit_auth_backend_ldap]}
     ]},
     {rabbitmq_auth_backend_ldap, [
-        {servers,         [ "localhost"]},
+        {servers,         ["localhost"]},
         {user_dn_pattern, "cn=${username},ou=People,dc=example,dc=com"},
         {tag_queries, [
             {administrator, {constant, false}},
             {management,    {constant, true}}
         ]},
-        {log, network}
+        {log, network_unsafe}
     ]}
 ].
 ```
-> This same configuration is available in the file rabbitmq.config should you want to copy files.
+
+This same configuration is available in the file rabbitmq.config should you want to copy files.
 
 **Configuration explained**:
 

--- a/only-authentication/rabbitmq.config
+++ b/only-authentication/rabbitmq.config
@@ -1,14 +1,14 @@
 [
     {rabbit, [
-      {auth_backends, [rabbit_auth_backend_ldap]}
+        {auth_backends, [rabbit_auth_backend_ldap]}
     ]},
     {rabbitmq_auth_backend_ldap, [
-        {servers,          [ "localhost"]  },
-        {user_dn_pattern,  "cn=${username},ou=People,dc=example,dc=com" },
+        {servers,          ["localhost"]},
+        {user_dn_pattern,  "cn=${username},ou=People,dc=example,dc=com"},
         {tag_queries, [
-            {administrator, {constant, false} },
-            {management,    {constant, true } }
+            {administrator, {constant, false}},
+            {management,    {constant, true }}
         ]},
-        {log, network}
+        {log, network_unsafe}
     ]}
 ].


### PR DESCRIPTION
Mostly whitespace. Also, it is customary for readme files to be named `README.md`